### PR TITLE
A few ports from previous projects; Largely wrapping lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,6 +814,12 @@
                 }
             }
         },
+        "@types/lodash": {
+            "version": "4.14.108",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
+            "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "13.11.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
@@ -3722,8 +3728,7 @@
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-            "dev": true
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash.memoize": {
             "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     },
     "dependencies": {
         "axios": "0.19.2",
-        "immutable": "4.0.0-rc.12"
+        "immutable": "4.0.0-rc.12",
+        "lodash": "4.17.15"
     },
     "description": "Common patterns, functions, etc... used when building react applications",
     "devDependencies": {
         "@testing-library/jest-dom": "5.5.0",
         "@testing-library/react": "10.0.4",
         "@types/jest": "25.1.5",
+        "@types/lodash": "4.14.108",
         "@types/node": "13.11.0",
         "@types/rosie": "0.0.37",
         "jest": "25.5.4",

--- a/src/constants/video-resolutions.ts
+++ b/src/constants/video-resolutions.ts
@@ -1,0 +1,65 @@
+const VideoResolutions = [
+    {
+        height: 1080,
+        label: "1080p(FHD)",
+        ratio: "16:9",
+        width: 1920,
+    },
+    {
+        height: 1200,
+        label: "UXGA",
+        ratio: "4:3",
+        width: 1600,
+    },
+    {
+        height: 720,
+        label: "720p(HD)",
+        ratio: "16:9",
+        width: 1280,
+    },
+    {
+        height: 600,
+        label: "SVGA",
+        ratio: "4:3",
+        width: 800,
+    },
+    {
+        height: 480,
+        label: "VGA",
+        ratio: "4:3",
+        width: 640,
+    },
+    {
+        height: 360,
+        label: "360p(nHD)",
+        ratio: "16:9",
+        width: 640,
+    },
+    {
+        height: 288,
+        label: "CIF",
+        ratio: "4:3",
+        width: 352,
+    },
+    {
+        height: 240,
+        label: "QVGA",
+        ratio: "4:3",
+        width: 320,
+    },
+    {
+        height: 144,
+        label: "QCIF",
+        ratio: "4:3",
+        width: 176,
+    },
+    {
+        height: 120,
+        label: "QQVGA",
+        ratio: "4:3",
+        width: 160,
+    },
+
+];
+
+export { VideoResolutions };

--- a/src/interfaces/key-value-pair.ts
+++ b/src/interfaces/key-value-pair.ts
@@ -1,0 +1,6 @@
+interface KeyValuePair<TKey, TValue> {
+    key: TKey;
+    value: TValue;
+}
+
+export { KeyValuePair };

--- a/src/tests/mocks/mock-axios.ts
+++ b/src/tests/mocks/mock-axios.ts
@@ -64,19 +64,19 @@ interface MockAxios {
 // ---------------------------------------------------------
 
 const deleteSuccess = (record?: any, delay?: number) =>
-    _mockSuccess(mockAxios.delete, record, delay);
+    _mockSuccess(MockAxios.delete, record, delay);
 
 const getSuccess = (record: any, delay?: number) =>
-    _mockSuccess(mockAxios.get, record, delay);
+    _mockSuccess(MockAxios.get, record, delay);
 
 const listSuccess = (records: any[], delay?: number) =>
-    _mockSuccess(mockAxios.get, records, delay);
+    _mockSuccess(MockAxios.get, records, delay);
 
 const postSuccess = (record: any, delay?: number) =>
-    _mockSuccess(mockAxios.post, record, delay);
+    _mockSuccess(MockAxios.post, record, delay);
 
 const putSuccess = (record: any, delay?: number) =>
-    _mockSuccess(mockAxios.put, record, delay);
+    _mockSuccess(MockAxios.put, record, delay);
 
 // #endregion Public Functions
 
@@ -131,7 +131,7 @@ const _resultObjectToJS = (resultObject: any | any[]): any | any[] => {
 // #region Exports
 // ---------------------------------------------------------
 
-const mockAxios: MockAxios = {
+export const MockAxios: MockAxios = {
     delete: axios.delete as AxiosJestMock,
     deleteSuccess,
     get: axios.get as AxiosJestMock,
@@ -142,7 +142,5 @@ const mockAxios: MockAxios = {
     put: axios.put as AxiosJestMock,
     putSuccess,
 };
-
-export default mockAxios;
 
 // #endregion Exports

--- a/src/types/cancellable-promise.ts
+++ b/src/types/cancellable-promise.ts
@@ -1,0 +1,6 @@
+type CancellablePromise<T = any> = {
+    cancel: () => void;
+    promise: Promise<T>;
+};
+
+export { CancellablePromise };

--- a/src/utilities/collection-utils.ts
+++ b/src/utilities/collection-utils.ts
@@ -1,4 +1,5 @@
 import { List } from "immutable";
+import _ from "lodash";
 
 // -----------------------------------------------------------------------------------------
 // #region Private Methods
@@ -180,12 +181,18 @@ const _replaceElementAt = <T>(
 // -----------------------------------------------------------------------------------------
 
 export const CollectionUtils = {
+    difference: _.difference,
     equalsBy: _equalsBy,
+    first: _.head,
+    flattenDeep: _.flattenDeep,
     hasValues: _hasValues,
     isEmpty: _isEmpty,
     isNotEmpty: _isNotEmpty,
     length: _length,
     replaceElementAt: _replaceElementAt,
+    sample: _.sample,
+    sampleSize: _.sampleSize,
+    take: _.take,
 };
 
 // #endregion Exports

--- a/src/utilities/core-utils.ts
+++ b/src/utilities/core-utils.ts
@@ -1,4 +1,5 @@
 import { CollectionUtils } from "./collection-utils";
+import _ from "lodash";
 
 // -----------------------------------------------------------------------------------------
 // #region Private Methods
@@ -84,10 +85,16 @@ const _timer = (name: string) => {
 // -----------------------------------------------------------------------------------------
 
 export const CoreUtils = {
+    bindAll: _.bindAll,
+    curry: _.curry,
+    memoize: _.memoize,
     numericEnumToPojo: _numericEnumToPojo,
     objectToArray: _objectToArray,
+    range: _.range,
     sleep: _sleep,
+    throttle: _.throttle,
     timer: _timer,
+    times: _.times,
 };
 
 // #endregion Exports

--- a/src/utilities/environment-utils.test.ts
+++ b/src/utilities/environment-utils.test.ts
@@ -1,0 +1,87 @@
+import EnvUtils from "./environment-utils";
+
+describe("EnvironmentUtils", () => {
+    const originalEnv = process.env;
+
+    // Save old process.env and replace it after each test
+    // See https://stackoverflow.com/a/48042799 for reference
+    beforeEach(() => {
+        jest.resetModules(); // this is important - it clears the cache
+        process.env = { ...originalEnv };
+        delete process.env;
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    // -----------------------------------------------------------------------------------------
+    // #region isDevelopment()
+    // -----------------------------------------------------------------------------------------
+
+    describe("isDevelopment()", () => {
+        test("when process.env.NODE_ENV is set to 'development', it returns true", () => {
+            // Arrange
+            const newEnv = { ...originalEnv };
+            newEnv.NODE_ENV = "development";
+            process.env = newEnv;
+
+            // Act
+            const result = EnvUtils.isDevelopment();
+
+            // Assert
+            expect(result).toBeTrue();
+        });
+
+        test("when process.env.NODE_ENV is set to 'production', it returns false", () => {
+            // Arrange
+            const newEnv = { ...originalEnv };
+            newEnv.NODE_ENV = "production";
+            process.env = newEnv;
+
+            // Act
+            const result = EnvUtils.isDevelopment();
+
+            // Assert
+            expect(result).toBeFalse();
+        });
+    });
+
+    // #endregion isDevelopment()
+
+    // -----------------------------------------------------------------------------------------
+    // #region runIfDevelopment()
+    // -----------------------------------------------------------------------------------------
+
+    describe("runIfDevelopment()", () => {
+        test("when process.env.NODE_ENV is set to 'development', it runs the function", () => {
+            // Arrange
+            const newEnv = { ...originalEnv };
+            newEnv.NODE_ENV = "development";
+            process.env = newEnv;
+            const fn = jest.fn();
+
+            // Act
+            EnvUtils.runIfDevelopment(() => fn());
+
+            // Assert
+            expect(fn).toHaveBeenCalled();
+        });
+
+        test("when process.env.NODE_ENV is set to 'production', it does not run the function", () => {
+            // Arrange
+            const newEnv = { ...originalEnv };
+            newEnv.NODE_ENV = "production";
+            process.env = newEnv;
+            const fn = jest.fn();
+
+            // Act
+            EnvUtils.runIfDevelopment(() => fn());
+
+            // Assert
+            expect(fn).not.toHaveBeenCalled();
+        });
+    });
+
+    // #endregion runIfDevelopment()
+});

--- a/src/utilities/environment-utils.test.ts
+++ b/src/utilities/environment-utils.test.ts
@@ -1,4 +1,4 @@
-import EnvUtils from "./environment-utils";
+import { EnvironmentUtils } from "./environment-utils";
 
 describe("EnvironmentUtils", () => {
     const originalEnv = process.env;
@@ -27,7 +27,7 @@ describe("EnvironmentUtils", () => {
             process.env = newEnv;
 
             // Act
-            const result = EnvUtils.isDevelopment();
+            const result = EnvironmentUtils.isDevelopment();
 
             // Assert
             expect(result).toBeTrue();
@@ -40,7 +40,7 @@ describe("EnvironmentUtils", () => {
             process.env = newEnv;
 
             // Act
-            const result = EnvUtils.isDevelopment();
+            const result = EnvironmentUtils.isDevelopment();
 
             // Assert
             expect(result).toBeFalse();
@@ -62,7 +62,7 @@ describe("EnvironmentUtils", () => {
             const fn = jest.fn();
 
             // Act
-            EnvUtils.runIfDevelopment(() => fn());
+            EnvironmentUtils.runIfDevelopment(() => fn());
 
             // Assert
             expect(fn).toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe("EnvironmentUtils", () => {
             const fn = jest.fn();
 
             // Act
-            EnvUtils.runIfDevelopment(() => fn());
+            EnvironmentUtils.runIfDevelopment(() => fn());
 
             // Assert
             expect(fn).not.toHaveBeenCalled();

--- a/src/utilities/environment-utils.ts
+++ b/src/utilities/environment-utils.ts
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------------------------
+// #region Functions
+// -----------------------------------------------------------------------------------------
+
+/**
+ * Function to return whether or not the current environment is development.
+ *
+ * @returns {boolean}
+ */
+const isDevelopment = (): boolean => {
+    return process.env.NODE_ENV === "development";
+};
+
+/**
+ * Conditionally runs the given function, depending on whether the current environment is development or not.
+ *
+ * @param {() => any} fn Function to be run in a development environment only.
+ */
+const runIfDevelopment = (fn: () => any): void => {
+    if (!isDevelopment()) {
+        return;
+    }
+
+    fn();
+};
+
+// #endregion Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Export
+// -----------------------------------------------------------------------------------------
+
+const EnvironmentUtils = {
+    isDevelopment,
+    runIfDevelopment,
+};
+
+export default EnvironmentUtils;
+
+// #endregion Export

--- a/src/utilities/environment-utils.ts
+++ b/src/utilities/environment-utils.ts
@@ -30,11 +30,9 @@ const runIfDevelopment = (fn: () => any): void => {
 // #region Export
 // -----------------------------------------------------------------------------------------
 
-const EnvironmentUtils = {
+export const EnvironmentUtils = {
     isDevelopment,
     runIfDevelopment,
 };
-
-export default EnvironmentUtils;
 
 // #endregion Export

--- a/src/utilities/promise-factory.ts
+++ b/src/utilities/promise-factory.ts
@@ -1,13 +1,4 @@
-// -----------------------------------------------------------------------------------------
-// #region Types
-// -----------------------------------------------------------------------------------------
-
-type CancellablePromise<T = any> = {
-    cancel: () => void;
-    promise: Promise<T>;
-};
-
-// #endregion Types
+import { CancellablePromise } from "../types/cancellable-promise";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Methods
@@ -49,6 +40,6 @@ const PromiseFactory = {
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export { CancellablePromise, PromiseFactory };
+export { PromiseFactory };
 
 // #endregion Exports

--- a/src/utilities/route-utils.test.ts
+++ b/src/utilities/route-utils.test.ts
@@ -167,6 +167,50 @@ describe("RouteUtils", () => {
     // #endregion getUrlFromPath
 
     // -----------------------------------------------------------------------------------------
+    // #region isAbsoluteUrl
+    // -----------------------------------------------------------------------------------------
+
+    describe("isAbsoluteUrl", () => {
+        test("when given url of null, returns false", () => {
+            expect(RouteUtils.isAbsoluteUrl(null)).toBeFalse();
+        });
+
+        test("when given url of undefined, returns false", () => {
+            expect(RouteUtils.isAbsoluteUrl(undefined)).toBeFalse();
+        });
+
+        test("when given url of empty string, returns false", () => {
+            expect(RouteUtils.isAbsoluteUrl("")).toBeFalse();
+        });
+
+        test("when given url of string with whitespace, returns false", () => {
+            expect(RouteUtils.isAbsoluteUrl("  ")).toBeFalse();
+        });
+
+        test("when given url of relative path, returns false", () => {
+            expect(RouteUtils.isAbsoluteUrl("/test/relative/path")).toBeFalse();
+        });
+
+        test("when given url without protocol, returns false", () => {
+            expect(
+                RouteUtils.isAbsoluteUrl("://test/relative/path")
+            ).toBeFalse();
+        });
+
+        test("when given url only with protocol, returns true", () => {
+            expect(RouteUtils.isAbsoluteUrl("http://")).toBeTrue();
+        });
+
+        test("when given url with protocol and path components, returns true", () => {
+            expect(
+                RouteUtils.isAbsoluteUrl("http://my.url/with/path")
+            ).toBeTrue();
+        });
+    });
+
+    //#endregion isAbsoluteUrl
+
+    // -----------------------------------------------------------------------------------------
     // #region replacePathParams
     // -----------------------------------------------------------------------------------------
 

--- a/src/utilities/route-utils.ts
+++ b/src/utilities/route-utils.ts
@@ -66,6 +66,13 @@ const getUrlFromPath = (path: string, pathParams?: any, queryParams?: any) => {
 };
 
 /**
+ * Determines if supplied url is an absolute url
+ * @param url
+ */
+const isAbsoluteUrl = (url: string): boolean =>
+    new RegExp("^(?:[a-z]+:)?//", "i").test(url);
+
+/**
  * Replace routing components in supplied path with keys and values
  * of supplied pathParams.
  * @param path Path containing routing components (format: ':key').
@@ -102,6 +109,7 @@ export const RouteUtils = {
     appendQueryParams,
     getUrl,
     getUrlFromPath,
+    isAbsoluteUrl,
     replacePathParams,
 };
 

--- a/src/utilities/string-utils.test.ts
+++ b/src/utilities/string-utils.test.ts
@@ -2,6 +2,32 @@ import StringUtils from "./string-utils";
 
 describe("StringUtils", () => {
     // -------------------------------------------------------------------------------------------------
+    // #region filename
+    // -------------------------------------------------------------------------------------------------
+
+    describe("filename", (): void => {
+        test.each`
+            inputString                       | expected
+            ${null}                           | ${undefined}
+            ${undefined}                      | ${undefined}
+            ${""}                             | ${""}
+            ${"/"}                            | ${""}
+            ${"path/no-extension"}            | ${"no-extension"}
+            ${"path/f.extension"}             | ${"f.extension"}
+            ${"multi/level/file.name"}        | ${"file.name"}
+            ${"mult1/l3v3l/f1l3.nam3"}        | ${"f1l3.nam3"}
+            ${"mult1/l3v3l/file with.spaces"} | ${"file with.spaces"}
+        `(
+            `when inputString is $inputString, returns $expected`,
+            ({ inputString, expected }: any): void => {
+                expect(StringUtils.filename(inputString)).toBe(expected);
+            }
+        );
+    });
+
+    //#endregion filename
+
+    // -------------------------------------------------------------------------------------------------
     // #region hasValue
     // -------------------------------------------------------------------------------------------------
 

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -67,11 +67,23 @@ const truncateRight = (value: string, truncateAtPos: number): string => {
 // -----------------------------------------------------------------------------------------
 
 const StringUtils = {
+    camelCase: _.camelCase,
+    capitalize: _.capitalize,
     filename,
     hasValue,
     isEmpty,
     isValidEmail,
+    lowerFirst: _.lowerFirst,
+    pad: _.pad,
+    padEnd: _.padEnd,
+    padStart: _.padStart,
+    repeat: _.repeat,
+    snakeCase: _.snakeCase,
+    startCase: _.startCase,
+    template: _.template,
     truncateRight,
+    upperFirst: _.upperFirst,
+    words: _.words,
 };
 
 export default StringUtils;

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 // -----------------------------------------------------------------------------------------
 // #region Constants
 // -----------------------------------------------------------------------------------------
@@ -9,6 +11,13 @@ const REGEX_VALID_EMAIL = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(
 // -----------------------------------------------------------------------------------------
 // #region Functions
 // -----------------------------------------------------------------------------------------
+
+/**
+ * Returns the filename from the supplied string, including extension
+ * @param value
+ */
+const filename = (value?: string): string | undefined =>
+    value?.split("/").pop();
 
 /**
  * Determines whether or not the provided value is NOT `undefined`, `null`, or an empty string
@@ -58,6 +67,7 @@ const truncateRight = (value: string, truncateAtPos: number): string => {
 // -----------------------------------------------------------------------------------------
 
 const StringUtils = {
+    filename,
     hasValue,
     isEmpty,
     isValidEmail,

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,4 +1,12 @@
 // -----------------------------------------------------------------------------------------
+// #region Constants
+// -----------------------------------------------------------------------------------------
+
+const REGEX_VALID_EMAIL = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+//#endregion Constants
+
+// -----------------------------------------------------------------------------------------
 // #region Functions
 // -----------------------------------------------------------------------------------------
 
@@ -11,7 +19,7 @@
  */
 const hasValue = (value?: string): boolean =>
     // toString is called here to ensure handling all edge cases when a non string value is passed in this fuction
-    value != null && value.toString().trim() !== "";
+    value != null && value?.toString().trim() !== "";
 
 /**
  * Determines whether or not the provided value is `undefined`, `null`, or an empty string
@@ -29,10 +37,7 @@ const isEmpty = (value?: string): boolean =>
  * @param value
  */
 const isValidEmail = (value?: string): boolean =>
-    value != null &&
-    new RegExp(
-        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-    ).test(value);
+    value != null && REGEX_VALID_EMAIL.test(value);
 
 const truncateRight = (value: string, truncateAtPos: number): string => {
     if (value.length <= truncateAtPos) {


### PR DESCRIPTION
For years we stood on the shoulders of giants and didn't recreate the wheel by writing/copying in utility methods that already exist. In an effort to get back to that we are going to wrap the performance optimized lodash library for common functionality. 

Why not just use lodash directly?
(1) Easier refactoring later (ie. add more functionality, extend lodash, make our custom utils easier to write
(2) Guides developers to follow similar XyzUtils.myFunction for implementation
(3) Makes it even faster for developers to spin up projects

Fixes issue #3 