### PR TITLE
Support/#15 service utils map paged axios response row count

### DIFF
--- a/src/utilities/service-utils.test.ts
+++ b/src/utilities/service-utils.test.ts
@@ -369,7 +369,7 @@ describe("ServiceUtils", () => {
             expect(result.resultObjects).toBeUndefined();
         });
 
-        test("it returns rowCount equal to the resultObject list length", () => {
+        test("when response.data.rowCount is undefined, it returns rowCount equal to the resultObject list length", () => {
             // Arrange
             const resultObject: StubResourceRecord[] = Factory.buildList(
                 FactoryType.StubResourceRecord,
@@ -380,6 +380,7 @@ describe("ServiceUtils", () => {
                 {
                     data: {
                         resultObject: resultObject,
+                        rowCount: undefined, // This is the important setup
                     },
                 }
             );
@@ -392,6 +393,61 @@ describe("ServiceUtils", () => {
 
             // Assert
             expect(result.rowCount).toBe(resultObject.length);
+        });
+
+        test("when response.data.rowCount is null, it returns rowCount equal to the resultObject list length", () => {
+            // Arrange
+            const resultObject: StubResourceRecord[] = Factory.buildList(
+                FactoryType.StubResourceRecord,
+                2
+            );
+            const axiosResponse = Factory.build<AxiosResponse>(
+                AndcultureCodeFactoryType.AxiosResponse,
+                {
+                    data: {
+                        resultObject: resultObject,
+                        rowCount: null, // This is the important setup
+                    },
+                }
+            );
+
+            // Act
+            const result = ServiceUtils.mapPagedAxiosResponse(
+                StubResourceRecord,
+                axiosResponse
+            );
+
+            // Assert
+            expect(result.rowCount).toBe(resultObject.length);
+        });
+
+        test("when response.data.rowCount has a value, it returns the mapped rowCount from the original response", () => {
+            // Arrange
+            const resultObject: StubResourceRecord[] = Factory.buildList(
+                FactoryType.StubResourceRecord,
+                2
+            );
+            const rowCount = faker.random.number({
+                min: resultObject.length + 1,
+            }); // This is the important setup (should be different from resultObject.length)
+            const axiosResponse = Factory.build<AxiosResponse>(
+                AndcultureCodeFactoryType.AxiosResponse,
+                {
+                    data: {
+                        resultObject: resultObject,
+                        rowCount: rowCount,
+                    },
+                }
+            );
+
+            // Act
+            const result = ServiceUtils.mapPagedAxiosResponse(
+                StubResourceRecord,
+                axiosResponse
+            );
+
+            // Assert
+            expect(result.rowCount).toBe(rowCount);
         });
 
         test("it returns the mapped status from the original response", () => {

--- a/src/utilities/service-utils.ts
+++ b/src/utilities/service-utils.ts
@@ -123,19 +123,24 @@ const _mapPagedAxiosResponse = <TRecord>(
     if (axiosResponse == null) {
         return null!;
     }
-    const data = axiosResponse.data;
+    const { data } = axiosResponse;
 
     // Ensure result data is wrapped within records
     let resultObjects;
+    let rowCount = 0;
     if (data?.resultObject?.length != null && data.resultObject.length > 0) {
-        resultObjects = data.resultObject.map((r) => new recordType(r));
-        data.resultObject = resultObjects;
+        resultObjects = data.resultObject.map((r: any) => new recordType(r));
+        rowCount = resultObjects.length;
+    }
+
+    if (data.rowCount != null) {
+        rowCount = data.rowCount;
     }
 
     return {
         results: new ResultRecord<TRecord[]>(data),
         resultObjects: resultObjects,
-        rowCount: data?.resultObject?.length ?? 0,
+        rowCount: rowCount,
         status: axiosResponse.status,
     };
 };

--- a/src/utilities/service-utils.ts
+++ b/src/utilities/service-utils.ts
@@ -7,6 +7,7 @@ import { ResultRecord } from "../view-models/result-record";
 import { PagedResult } from "../interfaces/paged-result";
 import { HttpHeader } from "../enumerations/http-header";
 import { ContentType } from "../enumerations/content-type";
+import { CollectionUtils } from "utilities/collection-utils";
 
 // -----------------------------------------------------------------------------------------
 // #region Variables
@@ -128,12 +129,15 @@ const _mapPagedAxiosResponse = <TRecord>(
     // Ensure result data is wrapped within records
     let resultObjects;
     let rowCount = 0;
-    if (data?.resultObject?.length != null && data.resultObject.length > 0) {
-        resultObjects = data.resultObject.map((r: any) => new recordType(r));
+    if (CollectionUtils.hasValues(data?.resultObject)) {
+        resultObjects = data.resultObject!.map((r: any) => new recordType(r));
+
+        // For now, record rowCount as the number of resultObjects we got back. We'll check the
+        // response for a rowCount of the total query set if the value was returned.
         rowCount = resultObjects.length;
     }
 
-    if (data.rowCount != null) {
+    if (data?.rowCount != null) {
         rowCount = data.rowCount;
     }
 


### PR DESCRIPTION
Fixes #15 

Minor refactor to leverage `CollectionUtils.hasValues` instead of manually null/length checking the returned array.

