### PR TITLE
Feature: RecordUtils.isRecord type guard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { CatchResultHandler } from "./types/catch-result-handler";
 export { Constructor } from "./types/constructor";
 export { FinallyHandler } from "./types/finally-handler";
 export { SyncWorkload } from "./types/sync-workload";
+export { TimerFunctionReturn } from "./types/timer-function-return";
 
 // #endregion Types
 

--- a/src/types/timer-function-return.ts
+++ b/src/types/timer-function-return.ts
@@ -1,0 +1,5 @@
+type TimerFunctionReturn = {
+    stop(log?: boolean): number;
+};
+
+export { TimerFunctionReturn };

--- a/src/utilities/core-utils.ts
+++ b/src/utilities/core-utils.ts
@@ -8,249 +8,241 @@ import {
 } from "lodash";
 
 // -----------------------------------------------------------------------------------------
-// #region Private Methods
+// #region Public Methods
 // -----------------------------------------------------------------------------------------
 
-/**
- * Binds methods of an object to the object itself, overwriting the existing method. Method names may be
- * specified as individual arguments or as arrays of method names. If no method names are provided all
- * enumerable function properties, own and inherited, of object are bound.
- *
- * Note: This method does not set the "length" property of bound functions.
- *
- * @param object The object to bind and assign the bound methods to.
- * @param methodNames The object method names to bind, specified as individual method names or arrays of
- * method names.
- * @return Returns object.
- */
-const bindAll = <T>(object: T, ...methodNames: Array<string | string[]>): T =>
-    _.bindAll(object, ...methodNames);
+const CoreUtils = {
+    /**
+     * Binds methods of an object to the object itself, overwriting the existing method. Method names may be
+     * specified as individual arguments or as arrays of method names. If no method names are provided all
+     * enumerable function properties, own and inherited, of object are bound.
+     *
+     * Note: This method does not set the "length" property of bound functions.
+     *
+     * @param object The object to bind and assign the bound methods to.
+     * @param methodNames The object method names to bind, specified as individual method names or arrays of
+     * method names.
+     * @return Returns object.
+     */
+    bindAll<T>(object: T, ...methodNames: Array<string | string[]>): T {
+        return _.bindAll(object, ...methodNames);
+    },
 
-/**
- * Creates a function that accepts one or more arguments of func that when called either invokes func returning
- * its result, if all func arguments have been provided, or returns a function that accepts one or more of the
- * remaining func arguments, and so on. The arity of func may be specified if func.length is not sufficient.
- * @param func The function to curry.
- * @param arity The arity of func.
- * @return Returns the new curried function.
- */
-const curry = <T1, R>(
-    func: (t1: T1) => R,
-    arity?: number
-): CurriedFunction1<T1, R> => _.curry(func, arity);
+    /**
+     * Creates a function that accepts one or more arguments of func that when called either invokes func returning
+     * its result, if all func arguments have been provided, or returns a function that accepts one or more of the
+     * remaining func arguments, and so on. The arity of func may be specified if func.length is not sufficient.
+     * @param func The function to curry.
+     * @param arity The arity of func.
+     * @return Returns the new curried function.
+     */
+    curry<T1, R>(func: (t1: T1) => R, arity?: number): CurriedFunction1<T1, R> {
+        return _.curry(func, arity);
+    },
 
-/**
- * Transforms an enum into an array of its values
- *
- * @example
- * const roleTypes = TestUtils.enumToArray<RoleType>(RoleType);
- * // Returns [0, 1, 2, 3, 4, 5]
- * @template TEnum The enum to be transformed
- * @param {*} enumObject The enum to be transformed (cannot be typed to TEnum, or TS will return 'typeof TEnum'
- * instead of a value of TEnum)
- * @returns {TEnum[]}
- */
-const enumToArray = <TEnum = any>(enumObject: any): TEnum[] =>
-    objectToArray(numericEnumToPojo(enumObject)) as TEnum[];
+    /**
+     * Transforms an enum into an array of its values
+     *
+     * @example
+     * const roleTypes = TestUtils.enumToArray<RoleType>(RoleType);
+     * // Returns [0, 1, 2, 3, 4, 5]
+     * @template TEnum The enum to be transformed
+     * @param {*} enumObject The enum to be transformed (cannot be typed to TEnum, or TS will return 'typeof TEnum'
+     * instead of a value of TEnum)
+     * @returns {TEnum[]}
+     */
+    enumToArray<TEnum = any>(enumObject: any): TEnum[] {
+        return CoreUtils.objectToArray(
+            CoreUtils.numericEnumToPojo(enumObject)
+        ) as TEnum[];
+    },
 
-/**
- * Returns a random enum value from its type
- *
- * @example
- * const randomRoleType = TestUtils.getRandomEnum<RoleType>(RoleType);
- * // Might return the value '1', which is the value of RoleType.Team
- * @template TEnum The enum to be transformed
- * @param {*} enumObject The enum to be transformed (cannot be typed to TEnum, or TS will return 'typeof TEnum'
- * instead of a value of TEnum)
- * @param {TEnum} [excludeElement] A specific enum value to be excluded from the random selection.
- * @returns {TEnum}
- */
-const getRandomEnum = <TEnum = any>(
-    enumObject: any,
-    excludeElement?: TEnum
-): TEnum => {
-    let enumValues = enumToArray(enumObject);
+    /**
+     * Returns a random enum value from its type
+     *
+     * @example
+     * const randomRoleType = TestUtils.getRandomEnum<RoleType>(RoleType);
+     * // Might return the value '1', which is the value of RoleType.Team
+     * @template TEnum The enum to be transformed
+     * @param {*} enumObject The enum to be transformed (cannot be typed to TEnum, or TS will return 'typeof TEnum'
+     * instead of a value of TEnum)
+     * @param {TEnum} [excludeElement] A specific enum value to be excluded from the random selection.
+     * @returns {TEnum}
+     */
+    getRandomEnum<TEnum = any>(enumObject: any, excludeElement?: TEnum): TEnum {
+        let enumValues = CoreUtils.enumToArray(enumObject);
 
-    if (excludeElement != null) {
-        enumValues = enumValues.filter((e: any) => e !== excludeElement);
-    }
-
-    return enumValues[Math.floor(Math.random() * enumValues.length)];
-};
-
-const memoize = <T extends (...args: any[]) => any>(
-    func: T,
-    resolver?: (...args: any[]) => any
-): T & MemoizedFunction => _.memoize(func, resolver);
-
-/**
- * Recursively merges own and inherited enumerable properties of source
- * objects into the destination object, skipping source properties that resolve
- * to `undefined`. Array and plain object properties are merged recursively.
- * Other objects and value types are overridden by assignment. Source objects
- * are applied from left to right. Subsequent sources overwrite property
- * assignments of previous sources.
- */
-const merge = <TObject, TSource>(
-    object: TObject,
-    source: TSource
-): TObject & TSource => _.merge(object, source);
-
-const numericEnumToPojo = (enumObject: any): {} => {
-    let pojo: { [k: string]: any } = {};
-
-    for (const key in enumObject) {
-        if (isNaN(parseInt(key))) {
-            pojo[key] = enumObject[key];
+        if (excludeElement != null) {
+            enumValues = enumValues.filter((e: any) => e !== excludeElement);
         }
-    }
 
-    return pojo;
-};
+        return enumValues[Math.floor(Math.random() * enumValues.length)];
+    },
 
-const objectToArray = (object: any): any[] => {
-    const result: any[] = [];
+    memoize<T extends (...args: any[]) => any>(
+        func: T,
+        resolver?: (...args: any[]) => any
+    ): T & MemoizedFunction {
+        return _.memoize(func, resolver);
+    },
 
-    if (CollectionUtils.isEmpty(object)) {
+    /**
+     * Recursively merges own and inherited enumerable properties of source
+     * objects into the destination object, skipping source properties that resolve
+     * to `undefined`. Array and plain object properties are merged recursively.
+     * Other objects and value types are overridden by assignment. Source objects
+     * are applied from left to right. Subsequent sources overwrite property
+     * assignments of previous sources.
+     */
+    merge<TObject, TSource>(
+        object: TObject,
+        source: TSource
+    ): TObject & TSource {
+        return _.merge(object, source);
+    },
+
+    numericEnumToPojo(enumObject: any): any {
+        let pojo: { [k: string]: any } = {};
+
+        for (const key in enumObject) {
+            if (isNaN(parseInt(key))) {
+                pojo[key] = enumObject[key];
+            }
+        }
+
+        return pojo;
+    },
+
+    objectToArray(object: any): any[] {
+        const result: any[] = [];
+
+        if (CollectionUtils.isEmpty(object)) {
+            return result;
+        }
+
+        for (const key in object) {
+            if (object.hasOwnProperty(key)) {
+                result.push(object[key]);
+            }
+        }
+
         return result;
-    }
+    },
 
-    for (const key in object) {
-        if (object.hasOwnProperty(key)) {
-            result.push(object[key]);
+    /**
+     * Creates an array of numbers (positive and/or negative) progressing from start up to, but not including, end.
+     * If end is not specified it’s set to start with start then set to 0. If end is less than start a zero-length
+     * range is created unless a negative step is specified.
+     *
+     * @param start The start of the range.
+     * @param end The end of the range.
+     * @param step The value to increment or decrement by.
+     * @return Returns a new range array.
+     */
+    range(start: number, end?: number, step?: number): number[] {
+        return _.range(start, end, step);
+    },
+
+    /**
+     * Wrap timeout in a promise so tests can easily block execution for testing time
+     * @param milliseconds
+     * @param debug
+     */
+    sleep(milliseconds: number, debug: boolean = false) {
+        if (debug) {
+            console.log("sleep start");
         }
-    }
 
-    return result;
+        return new Promise((resolve) =>
+            setTimeout(() => {
+                if (debug) {
+                    console.log("sleep end");
+                }
+
+                resolve();
+            }, milliseconds)
+        );
+    },
+
+    /**
+     * Block execution for specified number of milliseconds, synchronously.
+     * @param milliseconds the delay
+     */
+    sleepSync(milliseconds: number) {
+        let now = Date.now();
+        const start = now;
+        while (now - start < milliseconds) {
+            now = Date.now();
+        }
+    },
+
+    /**
+     * Creates a throttled function that only invokes func at most once per every wait milliseconds. The throttled
+     * function comes with a cancel method to cancel delayed invocations and a flush method to immediately invoke
+     * them. Provide an options object to indicate that func should be invoked on the leading and/or trailing edge
+     * of the wait timeout. Subsequent calls to the throttled function return the result of the last func call.
+     *
+     * Note: If leading and trailing options are true, func is invoked on the trailing edge of the timeout only if
+     * the the throttled function is invoked more than once during the wait timeout.
+     *
+     * @param func The function to throttle.
+     * @param wait The number of milliseconds to throttle invocations to.
+     * @param options The options object.
+     * @param options.leading Specify invoking on the leading edge of the timeout.
+     * @param options.trailing Specify invoking on the trailing edge of the timeout.
+     * @return Returns the new throttled function.
+     */ throttle<T extends (...args: any[]) => any>(
+        func: T,
+        wait?: number,
+        options?: ThrottleSettings
+    ): T & Cancelable {
+        return _.throttle(func, wait, options);
+    },
+
+    /**
+     * Creates a timer instance that when stopped will supply elapsed time in milliseconds.
+     * Useful for benchmarking or providing counters
+     * @param name Useful name to identify the timer
+     */
+    timer(name: string) {
+        const start = new Date();
+        return {
+            /**
+             * Stops the timer and returns elapsed time in milliseconds
+             * @param log Optional flag if you'd like the timer to log to the console
+             */
+            stop(log?: boolean): number {
+                var end = new Date();
+                var time = end.getTime() - start.getTime();
+
+                if (log === true) {
+                    console.log("Timer:", name, "finished in", time, "ms");
+                }
+
+                return time;
+            },
+        };
+    },
+
+    /**
+     * Invokes the iteratee function n times, returning an array of the results of each invocation. The iteratee
+     * is invoked with one argument; (index).
+     *
+     * @param n The number of times to invoke iteratee.
+     * @param iteratee The function invoked per iteration.
+     * @return Returns the array of results.
+     */
+    times<TResult>(n: number, iteratee: (num: number) => TResult): TResult[] {
+        return _.times(n, iteratee);
+    },
 };
 
-/**
- * Creates an array of numbers (positive and/or negative) progressing from start up to, but not including, end.
- * If end is not specified it’s set to start with start then set to 0. If end is less than start a zero-length
- * range is created unless a negative step is specified.
- *
- * @param start The start of the range.
- * @param end The end of the range.
- * @param step The value to increment or decrement by.
- * @return Returns a new range array.
- */
-const range = (start: number, end?: number, step?: number): number[] =>
-    _.range(start, end, step);
-
-/**
- * Wrap timeout in a promise so tests can easily block execution for testing time
- * @param milliseconds
- * @param debug
- */
-const sleep = (milliseconds: number, debug: boolean = false) => {
-    if (debug) {
-        console.log("sleep start");
-    }
-
-    return new Promise((resolve) =>
-        setTimeout(() => {
-            if (debug) {
-                console.log("sleep end");
-            }
-
-            resolve();
-        }, milliseconds)
-    );
-};
-
-/**
- * Block execution for specified number of milliseconds, synchronously.
- * @param milliseconds the delay
- */
-const sleepSync = (milliseconds: number) => {
-    let now = Date.now();
-    const start = now;
-    while (now - start < milliseconds) {
-        now = Date.now();
-    }
-};
-
-/**
- * Creates a throttled function that only invokes func at most once per every wait milliseconds. The throttled
- * function comes with a cancel method to cancel delayed invocations and a flush method to immediately invoke
- * them. Provide an options object to indicate that func should be invoked on the leading and/or trailing edge
- * of the wait timeout. Subsequent calls to the throttled function return the result of the last func call.
- *
- * Note: If leading and trailing options are true, func is invoked on the trailing edge of the timeout only if
- * the the throttled function is invoked more than once during the wait timeout.
- *
- * @param func The function to throttle.
- * @param wait The number of milliseconds to throttle invocations to.
- * @param options The options object.
- * @param options.leading Specify invoking on the leading edge of the timeout.
- * @param options.trailing Specify invoking on the trailing edge of the timeout.
- * @return Returns the new throttled function.
- */
-const throttle = <T extends (...args: any[]) => any>(
-    func: T,
-    wait?: number,
-    options?: ThrottleSettings
-): T & Cancelable => _.throttle(func, wait, options);
-
-/**
- * Creates a timer instance that when stopped will supply elapsed time in milliseconds.
- * Useful for benchmarking or providing counters
- * @param name Useful name to identify the timer
- */
-const timer = (name: string) => {
-    const start = new Date();
-    return {
-        /**
-         * Stops the timer and returns elapsed time in milliseconds
-         * @param log Optional flag if you'd like the timer to log to the console
-         */
-        stop(log?: boolean): number {
-            var end = new Date();
-            var time = end.getTime() - start.getTime();
-
-            if (log === true) {
-                console.log("Timer:", name, "finished in", time, "ms");
-            }
-
-            return time;
-        },
-    };
-};
-
-/**
- * Invokes the iteratee function n times, returning an array of the results of each invocation. The iteratee
- * is invoked with one argument; (index).
- *
- * @param n The number of times to invoke iteratee.
- * @param iteratee The function invoked per iteration.
- * @return Returns the array of results.
- */
-const times = <TResult>(
-    n: number,
-    iteratee: (num: number) => TResult
-): TResult[] => _.times(n, iteratee);
-
-// #endregion Private Methods
+// #endregion Public Methods
 
 // -----------------------------------------------------------------------------------------
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export const CoreUtils = {
-    bindAll,
-    curry,
-    enumToArray,
-    getRandomEnum,
-    memoize,
-    merge,
-    numericEnumToPojo,
-    objectToArray,
-    range,
-    sleep,
-    sleepSync,
-    throttle,
-    timer,
-    times,
-};
+export { CoreUtils };
 
 // #endregion Exports

--- a/src/utilities/core-utils.ts
+++ b/src/utilities/core-utils.ts
@@ -6,6 +6,7 @@ import {
     MemoizedFunction,
     ThrottleSettings,
 } from "lodash";
+import { TimerFunctionReturn } from "../types/timer-function-return";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Methods
@@ -79,6 +80,16 @@ const CoreUtils = {
         return enumValues[Math.floor(Math.random() * enumValues.length)];
     },
 
+    /**
+     * Creates a function that memoizes the result of func. If resolver is provided it determines the cache key for
+     * storing the result based on the arguments provided to the memoized function. By default, the first argument
+     * provided to the memoized function is coerced to a string and used as the cache key. The func is invoked with
+     * the this binding of the memoized function.
+     *
+     * @param func The function to have its output memoized.
+     * @param resolver The function to resolve the cache key.
+     * @return Returns the new memoizing function.
+     */
     memoize<T extends (...args: any[]) => any>(
         func: T,
         resolver?: (...args: any[]) => any
@@ -101,6 +112,12 @@ const CoreUtils = {
         return _.merge(object, source);
     },
 
+    /**
+     * Returns a plain javascript object based on the given enum
+     *
+     * @param {*} enumObject
+     * @returns {*}
+     */
     numericEnumToPojo(enumObject: any): any {
         let pojo: { [k: string]: any } = {};
 
@@ -113,6 +130,12 @@ const CoreUtils = {
         return pojo;
     },
 
+    /**
+     * Returns an array of an object's values
+     *
+     * @param {*} object
+     * @returns {any[]}
+     */
     objectToArray(object: any): any[] {
         const result: any[] = [];
 
@@ -148,12 +171,12 @@ const CoreUtils = {
      * @param milliseconds
      * @param debug
      */
-    sleep(milliseconds: number, debug: boolean = false) {
+    sleep(milliseconds: number, debug: boolean = false): Promise<void> {
         if (debug) {
             console.log("sleep start");
         }
 
-        return new Promise((resolve) =>
+        return new Promise<void>((resolve) =>
             setTimeout(() => {
                 if (debug) {
                     console.log("sleep end");
@@ -168,7 +191,7 @@ const CoreUtils = {
      * Block execution for specified number of milliseconds, synchronously.
      * @param milliseconds the delay
      */
-    sleepSync(milliseconds: number) {
+    sleepSync(milliseconds: number): void {
         let now = Date.now();
         const start = now;
         while (now - start < milliseconds) {
@@ -191,7 +214,8 @@ const CoreUtils = {
      * @param options.leading Specify invoking on the leading edge of the timeout.
      * @param options.trailing Specify invoking on the trailing edge of the timeout.
      * @return Returns the new throttled function.
-     */ throttle<T extends (...args: any[]) => any>(
+     */
+    throttle<T extends (...args: any[]) => any>(
         func: T,
         wait?: number,
         options?: ThrottleSettings
@@ -204,7 +228,7 @@ const CoreUtils = {
      * Useful for benchmarking or providing counters
      * @param name Useful name to identify the timer
      */
-    timer(name: string) {
+    timer(name: string): TimerFunctionReturn {
         const start = new Date();
         return {
             /**

--- a/src/utilities/record-utils.ts
+++ b/src/utilities/record-utils.ts
@@ -14,8 +14,8 @@ import { Constructor } from "../types/constructor";
  * @param maybeRecord Object or Record to be coalesced into a Record.
  * @param record Type of the Record to be instantiated
  */
-const _ensureRecord = <T>(maybeRecord: any, record: Constructor<T>): T =>
-    _isRecord(maybeRecord, record) ? maybeRecord : new record(maybeRecord);
+const ensureRecord = <T>(maybeRecord: any, record: Constructor<T>): T =>
+    isRecord(maybeRecord, record) ? maybeRecord : new record(maybeRecord);
 
 /**
  * Function to verify a given object is an instance of a specific Record `T`.
@@ -23,7 +23,10 @@ const _ensureRecord = <T>(maybeRecord: any, record: Constructor<T>): T =>
  * @param maybeRecord Object or Record to be checked as an instance of `T`
  * @param record Type of the Record to be checked
  */
-const _isRecord = <T>(maybeRecord: any, record: Constructor<T>): boolean =>
+const isRecord = <T>(
+    maybeRecord: any,
+    record: Constructor<T>
+): maybeRecord is T =>
     Record.isRecord(maybeRecord) && maybeRecord instanceof record;
 
 // #endregion Functions
@@ -33,8 +36,8 @@ const _isRecord = <T>(maybeRecord: any, record: Constructor<T>): boolean =>
 // -----------------------------------------------------------------------------------------
 
 const RecordUtils = {
-    ensureRecord: _ensureRecord,
-    isRecord: _isRecord,
+    ensureRecord,
+    isRecord,
 };
 
 export { RecordUtils };

--- a/src/utilities/record-utils.ts
+++ b/src/utilities/record-utils.ts
@@ -2,43 +2,41 @@ import { Record } from "immutable";
 import { Constructor } from "../types/constructor";
 
 // -----------------------------------------------------------------------------------------
-// #region Functions
+// #region Public Functions
 // -----------------------------------------------------------------------------------------
 
-/**
- * Function to ensure a given object is an instance of a specific Record `T`. If it is not, one will
- * be instantiated with the given constructor.
- *
- * If `maybeRecord` is already an instance of `T`, it returns that value.
- *
- * @param maybeRecord Object or Record to be coalesced into a Record.
- * @param record Type of the Record to be instantiated
- */
-const ensureRecord = <T>(maybeRecord: any, record: Constructor<T>): T =>
-    isRecord(maybeRecord, record) ? maybeRecord : new record(maybeRecord);
+const RecordUtils = {
+    /**
+     * Function to ensure a given object is an instance of a specific Record `T`. If it is not, one will
+     * be instantiated with the given constructor.
+     *
+     * If `maybeRecord` is already an instance of `T`, it returns that value.
+     *
+     * @param maybeRecord Object or Record to be coalesced into a Record.
+     * @param record Type of the Record to be instantiated
+     */
+    ensureRecord<T>(maybeRecord: any, record: Constructor<T>): T {
+        return RecordUtils.isRecord(maybeRecord, record)
+            ? maybeRecord
+            : new record(maybeRecord);
+    },
 
-/**
- * Function to verify a given object is an instance of a specific Record `T`.
- *
- * @param maybeRecord Object or Record to be checked as an instance of `T`
- * @param record Type of the Record to be checked
- */
-const isRecord = <T>(
-    maybeRecord: any,
-    record: Constructor<T>
-): maybeRecord is T =>
-    Record.isRecord(maybeRecord) && maybeRecord instanceof record;
+    /**
+     * Function to verify a given object is an instance of a specific Record `T`.
+     *
+     * @param maybeRecord Object or Record to be checked as an instance of `T`
+     * @param record Type of the Record to be checked
+     */
+    isRecord<T>(maybeRecord: any, record: Constructor<T>): maybeRecord is T {
+        return Record.isRecord(maybeRecord) && maybeRecord instanceof record;
+    },
+};
 
-// #endregion Functions
+// #endregion Public Functions
 
 // -----------------------------------------------------------------------------------------
 // #region Exports
 // -----------------------------------------------------------------------------------------
-
-const RecordUtils = {
-    ensureRecord,
-    isRecord,
-};
 
 export { RecordUtils };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
         "noUnusedParameters": true,
         "outDir": "./dist",
         "resolveJsonModule": true,
+        "removeComments": false,
         "skipLibCheck": true,
         "strict": true,
         "target": "es5"


### PR DESCRIPTION
Closes #83 Add type guard for RecordUtils.isRecord
Partially fixes #51 Declaration files do not retain JSDoc comments

Added some commentary in #51, but we will want to start restructuring where the utility objects are defined in order to retain our jsdoc comments in the `.d.ts` files that are generated. I've done this refactor for the `CoreUtils` and `RecordUtils` objects, but we can consider breaking out separate issues for each of the remaining ones, or umbrella them under #51.


- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
