### PR TITLE
Revert axios upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,11 +1531,11 @@
             "dev": true
         },
         "axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
             "requires": {
-                "follow-redirects": "^1.10.0"
+                "follow-redirects": "1.5.10"
             }
         },
         "babel-jest": {
@@ -3661,9 +3661,27 @@
             }
         },
         "follow-redirects": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-            "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -8820,7 +8838,6 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -8839,7 +8856,6 @@
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -8872,7 +8888,6 @@
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -8885,7 +8900,6 @@
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -8941,7 +8955,6 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -8951,7 +8964,6 @@
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -8963,7 +8975,6 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -8997,7 +9008,6 @@
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-number": "^3.0.0",
                         "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@types/lodash": "4.14.108",
-        "axios": "0.21.1",
+        "axios": "0.19.2",
         "humanize-plus": "1.8.2",
         "i18next": "19.4.5",
         "immutable": "4.0.0-rc.12",


### PR DESCRIPTION
See https://github.com/AndcultureCode/AndcultureCode.JavaScript.React/issues/60
We're going to need to work on the core package soon (client project looking to use localization utils), and the current upgrades from axios are breaking our service factory. While this isn't ideal, I think we need to revert this change for now and circle back to the upgrade to figure out where the breakdown is happening.


Revert axios to 0.19.2 until further time can be invested in upgrade path for core + react packages

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
