### PR TITLE
Allow consumers to control 'debug' option for i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "test": "jest ./src",
         "test-cypress": "cypress run",
         "validate-peer-dependencies": "node validate-peer-dependencies.js",
-        "watch": "npm run build -- --watch",
+        "watch": "tsc --pretty --watch",
         "watch:coverage": "jest ./src --coverage --watch",
         "watch:test": "jest ./src --watch"
     },

--- a/src/utilities/localization-utils.ts
+++ b/src/utilities/localization-utils.ts
@@ -31,6 +31,7 @@ const detectionOptions: DetectorOptions = {
 };
 
 const defaultInitOptions: LocalizationInitOptions = {
+    debug: EnvironmentUtils.isDevelopment(),
     detection: detectionOptions,
     escapeValue: false,
 };
@@ -42,8 +43,9 @@ const defaultInitOptions: LocalizationInitOptions = {
 // -----------------------------------------------------------------------------------------
 
 interface LocalizationInitOptions
-    extends Pick<InterpolationOptions, "escapeValue">,
-        Pick<InitOptions, "detection"> {}
+    extends Pick<InitOptions, "debug">,
+        Pick<InitOptions, "detection">,
+        Pick<InterpolationOptions, "escapeValue"> {}
 
 // #endregion Interfaces
 
@@ -128,7 +130,7 @@ const detectCultureCode = () => {
  * Initialize frontend i18n module - typically in root/startup of application
  * @param module Third party module for use with i18next (ie. initReactI18next)
  * @param cultures List of supported language cultures
- * @param {LocalizationInitOptions} [options=defaultInitOptions] Additional options for configuring i18n detection
+ * @param options Additional options for configuring i18n detection
  */
 const initialize = <TResources>(
     module: any,
@@ -144,7 +146,7 @@ const initialize = <TResources>(
         .init({
             // Cannot set lng value when using LanguageDetector (https://stackoverflow.com/a/55143859)
             cleanCode: true, // language will be lowercased EN --> en while leaving full locales like en-US
-            debug: EnvironmentUtils.isDevelopment(), // logs info level to console output. Helps finding issues with loading not working.
+            debug: options.debug, // logs info level to console output. Helps finding issues with loading not working.
             detection: options.detection,
             fallbackLng: defaultCultureCode(), // language to use if translations in user language are not available.
             interpolation: {


### PR DESCRIPTION
Pass along 'debug' option from LocalizationInitOptions object, retain current default of EnvironmentUtils.isDevelopment(), fix 'watch' script in package.json

Resolves #96 Allow consumer to control 'debug' option for LocalizationUtils/i18next 
Resolves #81 npm run watch no longer runs tsc --watch 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
