### PR TITLE
Restructure dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ yarn add andculturecode-javascript-core --dev
 From there you can import the variety of modules.
 
 ```typescript
-import {
-    CollectionUtils,
-    CoreUtils
-} from "andculturecode-javascript-core";
+import { CollectionUtils, CoreUtils } from "andculturecode-javascript-core";
 ```
 
 You can also reference the global distribution package within a website which gives you access to the `AndcultureCode` namespace. See the example below
@@ -32,12 +29,17 @@ You can also reference the global distribution package within a website which gi
 <script src="https://unpkg.com/browse/andculturecode-javascript-core@[version-number]/dist/global/index.js"></script>
 
 <script>
-    var myAuthObject = AndcultureCode.RouteUtils.queryStringToObject('#token=bada55cafe')
+    var myAuthObject = AndcultureCode.RouteUtils.queryStringToObject(
+        "#token=bada55cafe"
+    );
 </script>
-
 ```
 
-**NOTE** - This source code relies on several peer dependencies, most of which are not included in this bundled global distribution.  You will likely want to reference these in your website prior to referencing the `andculture-javascript-core` global package.  See [test-global-distribution.html](./test-global-distribution.html) for the full list of dependencies.  Also note that peer dependencies are only required if your code will be executing code paths that utilize any of those peer dependencies.
+## Peer dependencies
+
+This package wraps several external packages for our own configuration and ease of use, such as `axios`, `i18next`, `lodash`, etc. If you are using the standard distribution of this package, these will need to be installed alongside this package, even if you do not plan on leveraging features that rely on them.
+
+If using the global distribution, you will likely want to reference these in your website prior to referencing this package. See [test-global-distribution.html](./test-global-distribution.html) for the full list of dependencies. Unlike the standard distribution, peer dependencies are only required if your code will be executing code paths that rely on those packages.
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,7 @@
             "version": "7.9.6",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
             "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             },
@@ -357,18 +358,9 @@
                 "regenerator-runtime": {
                     "version": "0.13.5",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-                    "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+                    "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+                    "dev": true
                 }
-            }
-        },
-        "@babel/runtime-corejs3": {
-            "version": "7.9.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz",
-            "integrity": "sha512-6toWAfaALQjt3KMZQc6fABqZwUDDuWzz+cAfPhqyEnzxvdWOAkjwPNxgF8xlmo7OWLsSjaKjsskpKHRLaMArOA==",
-            "dev": true,
-            "requires": {
-                "core-js-pure": "^3.0.0",
-                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/template": {
@@ -728,60 +720,6 @@
                 "type-detect": "4.0.8"
             }
         },
-        "@testing-library/dom": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.5.7.tgz",
-            "integrity": "sha512-835MiwAxQE7xjSrhpeJbv41UQRmsPJQ0tGfzWiJMdZj2LBbdG5cT8Z44Viv11/XucCmJHr/v8q7VpZnuSimscg==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.9.6",
-                "aria-query": "^4.0.2",
-                "dom-accessibility-api": "^0.4.4",
-                "pretty-format": "^25.5.0"
-            },
-            "dependencies": {
-                "pretty-format": {
-                    "version": "25.5.0",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^25.5.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
-            }
-        },
-        "@testing-library/jest-dom": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.5.0.tgz",
-            "integrity": "sha512-7sWHrpxG4Yd8TmryI7Rtbx8Ff4mbs3ASye3oshQIuHvsCR+QHgr7rTR/PfeXvOmwUwR36wSTTAvrLKsPmr6VEQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.9.2",
-                "@types/testing-library__jest-dom": "^5.0.2",
-                "chalk": "^3.0.0",
-                "css": "^2.2.4",
-                "css.escape": "^1.5.1",
-                "jest-diff": "^25.1.0",
-                "jest-matcher-utils": "^25.1.0",
-                "lodash": "^4.17.15",
-                "redent": "^3.0.0"
-            }
-        },
-        "@testing-library/react": {
-            "version": "10.0.4",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.0.4.tgz",
-            "integrity": "sha512-2e1B5debfuiIGbvUuiSXybskuh7ZTVJDDvG/IxlzLOY9Co/mKFj9hIklAe2nGZYcOUxFaiqWrRZ9vCVGzJfRlQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.9.6",
-                "@testing-library/dom": "^7.2.2",
-                "@types/testing-library__react": "^10.0.1"
-            }
-        },
         "@types/babel__core": {
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -902,7 +840,8 @@
         "@types/lodash": {
             "version": "4.14.108",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
-            "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
+            "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+            "dev": true
         },
         "@types/node": {
             "version": "13.11.0",
@@ -922,31 +861,6 @@
             "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
             "dev": true
         },
-        "@types/prop-types": {
-            "version": "15.7.3",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-            "dev": true
-        },
-        "@types/react": {
-            "version": "16.9.35",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-            "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
-            "dev": true,
-            "requires": {
-                "@types/prop-types": "*",
-                "csstype": "^2.2.0"
-            }
-        },
-        "@types/react-dom": {
-            "version": "16.9.8",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-            "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
-            "dev": true,
-            "requires": {
-                "@types/react": "*"
-            }
-        },
         "@types/rosie": {
             "version": "0.0.37",
             "resolved": "https://registry.npmjs.org/@types/rosie/-/rosie-0.0.37.tgz",
@@ -964,35 +878,6 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
-        },
-        "@types/testing-library__dom": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-7.0.2.tgz",
-            "integrity": "sha512-8yu1gSwUEAwzg2OlPNbGq+ixhmSviGurBu1+ivxRKq1eRcwdjkmlwtPvr9VhuxTq2fNHBWN2po6Iem3Xt5A6rg==",
-            "dev": true,
-            "requires": {
-                "pretty-format": "^25.1.0"
-            }
-        },
-        "@types/testing-library__jest-dom": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.7.0.tgz",
-            "integrity": "sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==",
-            "dev": true,
-            "requires": {
-                "@types/jest": "*"
-            }
-        },
-        "@types/testing-library__react": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.0.1.tgz",
-            "integrity": "sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==",
-            "dev": true,
-            "requires": {
-                "@types/react-dom": "*",
-                "@types/testing-library__dom": "*",
-                "pretty-format": "^25.1.0"
-            }
         },
         "@types/yargs": {
             "version": "15.0.5",
@@ -1376,16 +1261,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "aria-query": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
-            "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.7.4",
-                "@babel/runtime-corejs3": "^7.7.4"
-            }
-        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1534,6 +1409,7 @@
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
             "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "dev": true,
             "requires": {
                 "follow-redirects": "1.5.10"
             }
@@ -2306,12 +2182,6 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js-pure": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-            "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2455,24 +2325,6 @@
                 "randomfill": "^1.0.3"
             }
         },
-        "css": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-            "dev": true,
-            "requires": {
-                "inherits": "^2.0.3",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
-            }
-        },
-        "css.escape": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
-            "dev": true
-        },
         "cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2495,12 +2347,6 @@
                     "dev": true
                 }
             }
-        },
-        "csstype": {
-            "version": "2.6.10",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-            "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
-            "dev": true
         },
         "cyclist": {
             "version": "1.0.1",
@@ -2882,12 +2728,6 @@
                     "dev": true
                 }
             }
-        },
-        "dom-accessibility-api": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.4.tgz",
-            "integrity": "sha512-XBM62jdDc06IXSujkqw6BugEWiDkp6jphtzVJf1kgPQGvfzaU7/jRtRSF/mxc8DBCIm2LS3bN1dCa5Sfxx982A==",
-            "dev": true
         },
         "domain-browser": {
             "version": "1.2.0",
@@ -3664,6 +3504,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
             "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "dev": true,
             "requires": {
                 "debug": "=3.1.0"
             },
@@ -3672,6 +3513,7 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
                     "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -3679,7 +3521,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -4130,12 +3973,14 @@
         "humanize-plus": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
-            "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA="
+            "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=",
+            "dev": true
         },
         "i18next": {
             "version": "19.4.5",
             "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
             "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1"
             }
@@ -4144,6 +3989,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.0.1.tgz",
             "integrity": "sha512-3H+OsNQn3FciomUU0d4zPFHsvJv4X66lBelXk9hnIDYDsveIgT7dWZ3/VvcSlpKk9lvCK770blRZ/CwHMXZqWw==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.5.5"
             }
@@ -4172,7 +4018,8 @@
         "immutable": {
             "version": "4.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
-            "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+            "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==",
+            "dev": true
         },
         "import-local": {
             "version": "3.0.2",
@@ -4188,12 +4035,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
-        },
-        "indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
         "infer-owner": {
@@ -5899,7 +5740,8 @@
         "lodash": {
             "version": "4.17.19",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+            "dev": true
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -6141,12 +5983,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
-        },
-        "min-indent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-            "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
             "dev": true
         },
         "minimalistic-assert": {
@@ -7049,22 +6885,6 @@
             "requires": {
                 "resolve": "^1.1.6"
             }
-        },
-        "redent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-            "dev": true,
-            "requires": {
-                "indent-string": "^4.0.0",
-                "strip-indent": "^3.0.0"
-            }
-        },
-        "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-            "dev": true
         },
         "regex-not": {
             "version": "1.0.2",
@@ -8024,15 +7844,6 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
-        },
-        "strip-indent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-            "dev": true,
-            "requires": {
-                "min-indent": "^1.0.0"
-            }
         },
         "supports-color": {
             "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -8,30 +8,28 @@
         "url": "https://github.com/AndcultureCode/AndcultureCode.JavaScript.Core/issues"
     },
     "dependencies": {
-        "@types/lodash": "4.14.108",
-        "axios": "0.19.2",
-        "humanize-plus": "1.8.2",
-        "i18next": "19.4.5",
-        "i18next-browser-languagedetector": "6.0.1",
-        "immutable": "4.0.0-rc.12",
-        "lodash": "4.17.19",
         "query-string": "6.13.1"
     },
     "description": "Common patterns, functions, etc... used when building react applications",
     "devDependencies": {
-        "@testing-library/jest-dom": "5.5.0",
-        "@testing-library/react": "10.0.4",
         "@types/faker": "4.1.12",
         "@types/humanize-plus": "1.8.0",
         "@types/jest": "25.1.5",
+        "@types/lodash": "4.14.108",
         "@types/node": "13.11.0",
         "@types/rosie": "0.0.37",
         "andculturecode-javascript-testing": "0.0.1",
+        "axios": "0.19.2",
         "cross-env": "6.0.3",
         "cypress": "3.8.3",
         "faker": "4.1.0",
+        "humanize-plus": "1.8.2",
+        "i18next": "19.4.5",
+        "i18next-browser-languagedetector": "6.0.1",
+        "immutable": "4.0.0-rc.12",
         "jest": "25.5.4",
         "jest-extended": "0.11.5",
+        "lodash": "4.17.19",
         "prettier": "1.19.1",
         "rimraf": "2.6.2",
         "rosie": "2.0.1",
@@ -61,6 +59,14 @@
     "license": "ISC",
     "main": "dist/index",
     "name": "andculturecode-javascript-core",
+    "peerDependencies": {
+        "axios": "^0.19.2",
+        "humanize-plus": "^1.8.2",
+        "i18next": "^19.4.5",
+        "i18next-browser-languagedetector": "^6.0.1",
+        "immutable": "^4.0.0-rc.12",
+        "lodash": "^4.17.19"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/AndcultureCode/AndcultureCode.JavaScript.Core.git"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,3 @@
-import "@testing-library/jest-dom/extend-expect";
 import "jest-extended";
 
 require("jest-extended");


### PR DESCRIPTION
- Move axios, lodash, etc. prod dependencies to dev + peer dependencies and remove unused React testing-library deps
- Update README to reflect updated peer dependency usage and merge w/ existing documentation for global dist

Note: The only production dependency I left was `query-string`, since it seems to have been intentionally bundled in with the global distribution of the package. 

Fixes #95 Reevaluate production vs. peer/dev dependencies 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
