### PR TITLE
Lighten peer dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "main": "dist/index",
     "name": "andculturecode-javascript-core",
     "peerDependencies": {
-        "axios": "^0.19.2",
-        "humanize-plus": "^1.8.2",
-        "i18next": "^19.4.5",
-        "i18next-browser-languagedetector": "^6.0.1",
-        "immutable": "^4.0.0-rc.12",
-        "lodash": "^4.17.19"
+        "axios": "0.19 || 0.21",
+        "humanize-plus": ">=1.8.2",
+        "i18next": ">=19.4.5",
+        "i18next-browser-languagedetector": ">=6.0.1",
+        "immutable": ">=4.0.0-rc.12",
+        "lodash": ">=4.17.19"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Resolves #121 Lighten peer dependency version further

- Allow any higher versions for most peer deps, restrict axios to 0.19 or 0.21 as tested versions

---

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
