### PR TITLE
Add ContentLength among other common headers

### DIFF
--- a/src/enumerations/http-header.ts
+++ b/src/enumerations/http-header.ts
@@ -1,7 +1,13 @@
 enum HttpHeader {
     Accept = "Accept",
+    AcceptEncoding = "Accept-Encoding",
+    AcceptLanguage = "Accept-Language",
     CacheControl = "Cache-Control",
+    ContentLength = "Content-Length",
     ContentType = "Content-Type",
+    Cookie = "Cookie",
+    Date = "Date",
+    UserAgent = "User-Agent",
 }
 
 export { HttpHeader };


### PR DESCRIPTION
Resolves #136 Add 'Content-Length' HttpHeader enum 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
